### PR TITLE
Possible typo in docker and singularity scripts

### DIFF
--- a/docs/1_install.md
+++ b/docs/1_install.md
@@ -113,7 +113,6 @@ From: centos:centos7.6.1810
     cd /opt/software
     git clone https://github.com/quadram-institute-bioscience/dadaist2
     ./dadaist2/bin/dadaist2-getdb -d "dada2-unite" -o /dadaist_databases/
-    ./dadaist2/bin/dadaist2-getdb -d "dada2-unite" -o /dadaist_databases/
     ./dadaist2/bin/dadaist2-getdb -d "decipher-silva-138" -o /dadaist_databases/
 
 %runscript
@@ -184,7 +183,6 @@ From: centos:centos7.6.1810
     source /opt/software/conda/bin/activate /opt/software/conda_env
     cd /opt/software
     git clone https://github.com/quadram-institute-bioscience/dadaist2
-    ./dadaist2/bin/dadaist2-getdb -d "dada2-unite" -o /dadaist_databases/
     ./dadaist2/bin/dadaist2-getdb -d "dada2-unite" -o /dadaist_databases/
     ./dadaist2/bin/dadaist2-getdb -d "decipher-silva-138" -o /dadaist_databases/
 


### PR DESCRIPTION
Hello!
There are duplicated lines in Docker and Singularity scripts which fetch the UNITE database:
```
    ./dadaist2/bin/dadaist2-getdb -d "dada2-unite" -o /dadaist_databases/
    ./dadaist2/bin/dadaist2-getdb -d "dada2-unite" -o /dadaist_databases/
```
It doesn't harm because `dadaist` skips downloading if the database is found, but anyway the lines are redundant.

With kind regards,
Vladimir